### PR TITLE
Add recency check to skip stale tickers

### DIFF
--- a/MoneymakerPro_Alpha_fetchfix.py
+++ b/MoneymakerPro_Alpha_fetchfix.py
@@ -67,6 +67,12 @@ def analyze_stock_from_local_data(ticker, data, config, progress_queue=None):
             weekly_data = weekly_data.iloc[:-1]
         if weekly_data.empty: return None
 
+        latest_week = weekly_data.index[-1]
+        if (datetime.now().date() - latest_week.date()).days > 7:
+            if progress_queue:
+                progress_queue.put(f"Status: {ticker} has no recent data. Skipping.")
+            return None
+
         if len(weekly_data) < config['ma_periods']['short'] + 1: return None
         if len(weekly_data) < config['avg_volume_weeks'] + 1: return None
 

--- a/moneymaker_pro.py
+++ b/moneymaker_pro.py
@@ -52,6 +52,12 @@ def analyze_stock_from_local_data(ticker, data, config, progress_queue=None):
             weekly_data = weekly_data.iloc[:-1]
         if weekly_data.empty: return None
 
+        latest_week = weekly_data.index[-1]
+        if (datetime.now().date() - latest_week.date()).days > 7:
+            if progress_queue:
+                progress_queue.put(f"Status: {ticker} has no recent data. Skipping.")
+            return None
+
         if len(weekly_data) < config['ma_periods']['short'] + 1: return None
         if len(weekly_data) < config['avg_volume_weeks'] + 1: return None
 

--- a/moneymaker_pro_alpha.py
+++ b/moneymaker_pro_alpha.py
@@ -58,6 +58,14 @@ def analyze_stock_from_local_data(ticker, data, config, progress_queue=None, log
             if log_queue: log_queue.put(f"  -> SKIPPED: {ticker} - No weekly data after removing incomplete week.")
             return None
 
+        latest_week = weekly_data.index[-1]
+        if (datetime.now().date() - latest_week.date()).days > 7:
+            if progress_queue:
+                progress_queue.put(f"Status: {ticker} has no recent data. Skipping.")
+            if log_queue:
+                log_queue.put(f"  -> SKIPPED: {ticker} - No recent data.")
+            return None
+
         lookback_weeks = config.get('lookback_weeks', 1)
 
         for i in range(1, lookback_weeks + 1):


### PR DESCRIPTION
## Summary
- skip stocks whose latest weekly data is more than seven days old in all stock filter variants

## Testing
- `python -m py_compile moneymaker_pro.py moneymaker_pro_alpha.py MoneymakerPro_Alpha_fetchfix.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2a6ad95f48327a9546aafb7ad5a76