### PR TITLE
Add configurable workers for stock data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ The package exposes a small CLI. To fetch data into `stock_data.json` run:
 python -m moneymaker fetch asx_200_tickers.txt
 ```
 
+You can control the number of threads used when downloading data with the
+`--workers` option (default is 10):
+
+```bash
+python -m moneymaker fetch asx_200_tickers.txt --workers 20
+```
+
 ## Legacy Scripts
 
 The GUI application (`moneymaker_pro_alpha.py`) now depends on the new package and shares the

--- a/src/moneymaker/__main__.py
+++ b/src/moneymaker/__main__.py
@@ -24,10 +24,17 @@ def main() -> None:
         default=fetcher.DEFAULT_DATA_YEARS,
         help=f"Number of years of historical data (default: {fetcher.DEFAULT_DATA_YEARS})",
     )
+    fetch_cmd.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=fetcher.DEFAULT_WORKERS,
+        help=f"Number of threads for downloading data (default: {fetcher.DEFAULT_WORKERS})",
+    )
 
     args = parser.parse_args()
     if args.command == "fetch":
-        fetcher.fetch_stock_data(args.ticker_file, args.output, args.years)
+        fetcher.fetch_stock_data(args.ticker_file, args.output, args.years, args.workers)
     else:
         parser.print_help()
 

--- a/src/moneymaker/fetcher.py
+++ b/src/moneymaker/fetcher.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 DEFAULT_OUTPUT_FILE = "stock_data.json"
 DEFAULT_DATA_YEARS = 15
+DEFAULT_WORKERS = 10
 
 
 def get_tickers_from_file(filename: str) -> List[str]:
@@ -70,8 +71,26 @@ def fetch_info_individual(tickers: List[str]) -> Dict[str, dict]:
     return all_info_data
 
 
-def fetch_stock_data(ticker_file: str, output: str = DEFAULT_OUTPUT_FILE, years: int = DEFAULT_DATA_YEARS) -> None:
-    """Fetches historical and info data for tickers and saves to ``output``."""
+def fetch_stock_data(
+    ticker_file: str,
+    output: str = DEFAULT_OUTPUT_FILE,
+    years: int = DEFAULT_DATA_YEARS,
+    workers: int = DEFAULT_WORKERS,
+) -> None:
+    """Fetches historical and info data for tickers and saves to ``output``.
+
+    Parameters
+    ----------
+    ticker_file:
+        Path to a text file containing ticker symbols.
+    output:
+        Destination JSON file for fetched data.
+    years:
+        Number of years of historical data to retrieve.
+    workers:
+        Number of worker threads used by ``yfinance`` when downloading
+        historical prices.
+    """
     print("--- Starting Data Fetcher (Concurrent Mode) ---")
     print(f"Ticker File: {ticker_file}")
     print(f"Data Years: {years}")
@@ -97,7 +116,7 @@ def fetch_stock_data(ticker_file: str, output: str = DEFAULT_OUTPUT_FILE, years:
         end=end_date.strftime("%Y-%m-%d"),
         interval="1d",
         group_by="ticker",
-        threads=True,
+        threads=workers,
         progress=True,
     )
     print("Historical data fetch complete.")
@@ -162,8 +181,15 @@ def cli() -> None:
     parser.add_argument(
         "-y", "--years", type=int, default=DEFAULT_DATA_YEARS, help=f"Number of years of historical data to fetch. (Default: {DEFAULT_DATA_YEARS})"
     )
+    parser.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=DEFAULT_WORKERS,
+        help=f"Number of threads for downloading data. (Default: {DEFAULT_WORKERS})",
+    )
     args = parser.parse_args()
-    fetch_stock_data(args.ticker_file, args.output, args.years)
+    fetch_stock_data(args.ticker_file, args.output, args.years, args.workers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow fetch_stock_data to control yfinance download threads via new workers parameter
- expose --workers flag in moneymaker CLI and module-level cli
- document worker option and default in README

## Testing
- `PYTHONPATH=src python -m moneymaker.fetcher -h`
- `PYTHONPATH=src python -m moneymaker fetch -h`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2b41b85088327a29ec54ffc6d198a