### PR TITLE
Enforce MA requirements during screening

### DIFF
--- a/src/moneymaker/filters.py
+++ b/src/moneymaker/filters.py
@@ -69,17 +69,33 @@ def analyze_stock_from_local_data(
             return None
 
         lookback_weeks = config.get("lookback_weeks", 1)
+        ma_periods = {
+            name: int(period)
+            for name, period in (config.get("ma_periods") or {}).items()
+            if period and int(period) > 0
+        }
+
         for i in range(1, lookback_weeks + 1):
             if len(weekly_data) < i:
                 break
             target_week_index = -i
-            if len(weekly_data.iloc[:target_week_index]) < config["ma_periods"]["short"] + 1:
+            pre_target_slice = weekly_data.iloc[:target_week_index]
+            available_weeks = len(pre_target_slice)
+
+            missing_ma_periods = [
+                (name, period) for name, period in ma_periods.items() if available_weeks < period
+            ]
+            if missing_ma_periods:
                 if log_queue and i == 1:
+                    formatted_periods = ", ".join(
+                        f"{name} ({period} weeks)" for name, period in missing_ma_periods
+                    )
                     log_queue.put(
-                        f"  -> SKIPPED: {ticker} - Too young for shortest MA ({config['ma_periods']['short']} weeks)."
+                        f"  -> SKIPPED: {ticker} - Not enough data for moving averages: {formatted_periods}."
                     )
                 continue
-            if len(weekly_data.iloc[:target_week_index]) < config["avg_volume_weeks"] + 1:
+
+            if available_weeks < config["avg_volume_weeks"] + 1:
                 if log_queue and i == 1:
                     log_queue.put(
                         f"  -> SKIPPED: {ticker} - Not enough data for volume average ({config['avg_volume_weeks']} weeks)."
@@ -98,7 +114,7 @@ def analyze_stock_from_local_data(
             if not current_week_volume >= config["volume_multiplier"] * preceding_avg_volume:
                 continue
 
-            if len(weekly_data.iloc[:target_week_index]) < config.get("price_avg_weeks", 1):
+            if available_weeks < config.get("price_avg_weeks", 1):
                 continue
             current_week_close_price = weekly_data["Close"].iloc[target_week_index]
             if len(weekly_data) < i + 1:
@@ -115,15 +131,14 @@ def analyze_stock_from_local_data(
                 continue
 
             price_conditions_met = True
-            for ma_name, period in config["ma_periods"].items():
-                if len(weekly_data.iloc[:target_week_index]) >= period:
-                    ma_series = weekly_data["Close"].shift(1).rolling(
-                        window=period, min_periods=int(period * 0.8)
-                    ).mean()
-                    ma_value = ma_series.get(target_week_start_date, float("nan"))
-                    if pd.isna(ma_value) or current_week_close_price <= ma_value:
-                        price_conditions_met = False
-                        break
+            for ma_name, period in ma_periods.items():
+                ma_series = weekly_data["Close"].shift(1).rolling(
+                    window=period, min_periods=int(period * 0.8)
+                ).mean()
+                ma_value = ma_series.get(target_week_start_date, float("nan"))
+                if pd.isna(ma_value) or current_week_close_price <= ma_value:
+                    price_conditions_met = False
+                    break
 
             if price_conditions_met:
                 if market_cap is None:

--- a/src/moneymaker/tests/test_analyze_stock_from_local_data.py
+++ b/src/moneymaker/tests/test_analyze_stock_from_local_data.py
@@ -1,0 +1,104 @@
+"""Tests for :func:`moneymaker.filters.analyze_stock_from_local_data`."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from typing import Iterable, Tuple
+
+import pandas as pd
+
+from moneymaker.filters import analyze_stock_from_local_data
+
+
+def _build_history(closes: Iterable[float], volumes: Iterable[float]) -> Tuple[dict, pd.DatetimeIndex]:
+    """Create historical price data aligned to completed Mondays."""
+
+    closes = list(closes)
+    volumes = list(volumes)
+    if len(closes) != len(volumes):
+        raise ValueError("closes and volumes must be the same length")
+
+    today = datetime.now().date()
+    latest_monday = today - timedelta(days=today.weekday())
+    mondays = pd.date_range(end=pd.Timestamp(latest_monday), periods=len(closes), freq="W-MON")
+
+    frame = pd.DataFrame(
+        {
+            "Open": closes,
+            "High": closes,
+            "Low": closes,
+            "Close": closes,
+            "Volume": volumes,
+        },
+        index=mondays,
+    )
+
+    return json.loads(frame.to_json(orient="split")), mondays
+
+
+def _base_config(**overrides):
+    config = {
+        "lookback_weeks": 1,
+        "avg_volume_weeks": 2,
+        "volume_multiplier": 1.0,
+        "price_avg_weeks": 1,
+        "ma_periods": {"short": 2, "intermediate": 3},
+        "min_market_cap": 0,
+        "max_market_cap": 0,
+    }
+    config.update(overrides)
+    return config
+
+
+def _build_payload(closes: Iterable[float], volumes: Iterable[float]):
+    history, mondays = _build_history(closes, volumes)
+    payload = {
+        "info": {"marketCap": 5_000_000},
+        "history": history,
+    }
+    return payload, mondays
+
+
+def test_accepts_when_price_exceeds_all_configured_mas():
+    payload, mondays = _build_payload(
+        closes=[10, 11, 12, 13, 20],
+        volumes=[100, 110, 120, 130, 140],
+    )
+
+    result = analyze_stock_from_local_data("TEST", payload, _base_config())
+
+    assert result is not None
+    assert result["date"] == mondays[-1].strftime("%Y-%m-%d")
+    assert result["close_price"] == 20
+
+
+def test_rejects_when_missing_history_for_any_configured_ma():
+    payload, _ = _build_payload(
+        closes=[10, 11, 12, 13, 20],
+        volumes=[100, 110, 120, 130, 140],
+    )
+
+    result = analyze_stock_from_local_data(
+        "TEST",
+        payload,
+        _base_config(ma_periods={"short": 2, "long": 6}),
+    )
+
+    assert result is None
+
+
+def test_rejects_when_latest_price_not_above_all_mas():
+    payload, _ = _build_payload(
+        closes=[200, 190, 180, 170, 175],
+        volumes=[100, 110, 120, 130, 140],
+    )
+
+    result = analyze_stock_from_local_data(
+        "TEST",
+        payload,
+        _base_config(ma_periods={"short": 2, "intermediate": 4}),
+    )
+
+    assert result is None
+


### PR DESCRIPTION
## Summary
- require adequate history for every configured moving average before evaluating a week
- ensure price comparisons run against each requested moving average without skipping missing periods
- add regression tests covering valid selections, insufficient MA history, and prices below an MA

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d521c83c508327a50f7bbc68f06e68