### PR TITLE
Switch chart links to Yahoo Finance

### DIFF
--- a/moneymaker_pro_alpha.py
+++ b/moneymaker_pro_alpha.py
@@ -528,12 +528,9 @@ class MoneymakerProAlphaApp:
             item_id = tree.identify_row(event.y)
             if item_id:
                 raw_ticker = tree.item(item_id, 'values')[0]
-                # TradingView uses a different format for some exchanges, e.g., ASX:TICKER for .AX
-                if raw_ticker.endswith(".AX"):
-                    tv_symbol = f"ASX:{raw_ticker[:-3]}"
-                else:
-                    tv_symbol = raw_ticker  # Works for US stocks
-                url = f"https://www.tradingview.com/chart/?symbol={tv_symbol}"
+                # Yahoo Finance supports the standard ticker symbols including the .AX suffix
+                yf_symbol = raw_ticker
+                url = f"https://finance.yahoo.com/quote/{yf_symbol}/chart?p={yf_symbol}"
                 webbrowser.open_new_tab(url)
 
     def start_filter(self):


### PR DESCRIPTION
## Summary
- update the tree view click handler to open Yahoo Finance chart links instead of TradingView
- rely on the raw ticker symbol, which already matches Yahoo Finance expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d523f83edc8327b16b21e4407d5135