### PR TITLE
Improve fetcher resilience to yfinance errors

### DIFF
--- a/src/moneymaker/fetcher.py
+++ b/src/moneymaker/fetcher.py
@@ -4,7 +4,7 @@
 import json
 import time
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, Iterable, List, Set, Tuple
 
 import pandas as pd
 import yfinance as yf
@@ -71,6 +71,168 @@ def fetch_info_individual(tickers: List[str]) -> Dict[str, dict]:
     return all_info_data
 
 
+def _chunked(iterable: List[str], size: int) -> Iterable[List[str]]:
+    """Simple chunk generator used for batch downloads."""
+
+    for idx in range(0, len(iterable), size):
+        yield iterable[idx : idx + size]
+
+
+def _is_rate_limit_error(error: Exception) -> bool:
+    """Detects yfinance rate-limit style errors without direct imports."""
+
+    message = str(error)
+    return "rate limit" in message.lower() or "too many requests" in message.lower()
+
+
+def _is_invalid_period_error(error: Exception) -> bool:
+    """Detects invalid-period errors produced by yfinance."""
+
+    return "period 'max' is invalid" in str(error).lower()
+
+
+def _extract_histories_from_frame(chunk: List[str], data: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+    """Normalises the output of ``yfinance.download`` into ticker keyed frames."""
+
+    if data is None or data.empty:
+        return {}
+
+    if isinstance(data, pd.Series):
+        data = data.to_frame()
+
+    histories: Dict[str, pd.DataFrame] = {}
+    if isinstance(data.columns, pd.MultiIndex):
+        available = set(data.columns.get_level_values(0))
+        for ticker in chunk:
+            if ticker in available:
+                hist = data[ticker].dropna(how="all")
+                if not hist.empty:
+                    histories[ticker] = hist
+    else:
+        ticker = chunk[0]
+        hist = data.dropna(how="all")
+        if not hist.empty:
+            histories[ticker] = hist
+
+    return histories
+
+
+def _download_chunk_sequential(
+    chunk: List[str], start: datetime, end: datetime
+) -> Tuple[Dict[str, pd.DataFrame], Set[str]]:
+    """Sequentially downloads historical data for each ticker in ``chunk``."""
+
+    downloaded: Dict[str, pd.DataFrame] = {}
+    failures: Set[str] = set()
+
+    for ticker in chunk:
+        attempts = 0
+        while attempts < 3:
+            try:
+                data = yf.download(
+                    ticker,
+                    start=start.strftime("%Y-%m-%d"),
+                    end=end.strftime("%Y-%m-%d"),
+                    interval="1d",
+                    progress=False,
+                )
+            except Exception as exc:  # pragma: no cover - network error path
+                if _is_rate_limit_error(exc):
+                    wait_time = 30 * (attempts + 1)
+                    print(
+                        f"   [!] Rate limit hit while fetching {ticker} individually. "
+                        f"Sleeping {wait_time}s before retrying."
+                    )
+                    time.sleep(wait_time)
+                    attempts += 1
+                    continue
+                if _is_invalid_period_error(exc):
+                    failures.add(ticker)
+                    break
+                print(
+                    f"[-] Warning: Failed to fetch historical data for {ticker}. "
+                    f"Error: {str(exc)[:120]}"
+                )
+                failures.add(ticker)
+                break
+            else:
+                data = data.dropna(how="all")
+                if data.empty:
+                    failures.add(ticker)
+                else:
+                    downloaded[ticker] = data
+                break
+        else:
+            failures.add(ticker)
+    return downloaded, failures
+
+
+def _download_historical_data(
+    tickers: List[str], start: datetime, end: datetime, workers: int
+) -> Tuple[Dict[str, pd.DataFrame], Set[str]]:
+    """Downloads historical data in manageable batches with fallbacks."""
+
+    historical_data: Dict[str, pd.DataFrame] = {}
+    missing_tickers: Set[str] = set()
+
+    for chunk in _chunked(tickers, 100):
+        attempts = 0
+        while attempts < 3:
+            try:
+                data = yf.download(
+                    chunk,
+                    start=start.strftime("%Y-%m-%d"),
+                    end=end.strftime("%Y-%m-%d"),
+                    interval="1d",
+                    group_by="ticker",
+                    threads=workers,
+                    progress=False,
+                )
+            except RuntimeError as exc:  # pragma: no cover - network error path
+                if "dictionary changed size" in str(exc).lower():
+                    print(
+                        "   [!] Encountered yfinance internal error while downloading "
+                        f"chunk starting with {chunk[0]}. Falling back to sequential downloads."
+                    )
+                    sequential_data, seq_failures = _download_chunk_sequential(chunk, start, end)
+                    historical_data.update(sequential_data)
+                    missing_tickers.update(seq_failures)
+                    break
+                raise
+            except Exception as exc:  # pragma: no cover - network error path
+                if _is_rate_limit_error(exc):
+                    wait_time = 30 * (attempts + 1)
+                    print(
+                        f"   [!] Rate limit reached for chunk starting with {chunk[0]}. "
+                        f"Sleeping {wait_time}s before retrying."
+                    )
+                    time.sleep(wait_time)
+                    attempts += 1
+                    continue
+                if _is_invalid_period_error(exc):
+                    missing_tickers.update(chunk)
+                    break
+                print(
+                    f"[-] Warning: Failed to download chunk starting with {chunk[0]}. "
+                    f"Error: {str(exc)[:120]}"
+                )
+                missing_tickers.update(chunk)
+                break
+            else:
+                chunk_histories = _extract_histories_from_frame(chunk, data)
+                historical_data.update(chunk_histories)
+                missing = {ticker for ticker in chunk if ticker not in chunk_histories}
+                missing_tickers.update(missing)
+                break
+        else:
+            print(
+                f"[-] Warning: Exhausted retries while downloading chunk starting with {chunk[0]} due to rate limits."
+            )
+            missing_tickers.update(chunk)
+
+    return historical_data, missing_tickers
+
+
 def fetch_stock_data(
     ticker_file: str,
     output: str = DEFAULT_OUTPUT_FILE,
@@ -110,15 +272,13 @@ def fetch_stock_data(
     print("\n--- Step 1 of 3: Batch fetching historical data ---")
     end_date = datetime.now()
     start_date = end_date - pd.DateOffset(years=years)
-    hist_data_multi = yf.download(
-        tickers,
-        start=start_date.strftime("%Y-%m-%d"),
-        end=end_date.strftime("%Y-%m-%d"),
-        interval="1d",
-        group_by="ticker",
-        threads=workers,
-        progress=True,
-    )
+    start_dt = start_date.to_pydatetime() if hasattr(start_date, "to_pydatetime") else start_date
+    end_dt = end_date.to_pydatetime() if hasattr(end_date, "to_pydatetime") else end_date
+    hist_data, missing_hist_tickers = _download_historical_data(tickers, start_dt, end_dt, workers)
+    if missing_hist_tickers:
+        print(
+            f"   [!] Unable to fetch historical data for {len(missing_hist_tickers)} tickers during the batch step."
+        )
     print("Historical data fetch complete.")
 
     all_info_data = fetch_info_individual(tickers)
@@ -131,11 +291,8 @@ def fetch_stock_data(
 
     for ticker in tqdm(tickers, desc="Processing Tickers"):
         info = all_info_data.get(ticker)
-        if ticker not in hist_data_multi.columns.get_level_values(0):
-            tickers_no_hist += 1
-            continue
-        hist_single = hist_data_multi[ticker].dropna(how="all")
-        if hist_single.empty:
+        hist_single = hist_data.get(ticker)
+        if hist_single is None or hist_single.empty:
             tickers_no_hist += 1
             continue
         if not info:


### PR DESCRIPTION
## Summary
- download historical data in batches with detection for rate limit and invalid-period errors
- fall back to sequential per-ticker downloads when yfinance hits internal runtime issues
- propagate fetched history via dictionaries so tickers without data are skipped gracefully

## Testing
- python -m compileall src/moneymaker/fetcher.py

------
https://chatgpt.com/codex/tasks/task_e_68d53ad3a4b883279f86f7b5078d8b13