### PR TITLE
Require invited Firebase users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  python-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest
+
+      - name: Run tests
+        run: python -m pytest src/moneymaker/tests
+
+  functions-build:
+    name: Firebase Functions build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install Functions dependencies
+        run: npm ci
+
+      - name: Build Functions
+        run: npm run build

--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -47,6 +47,12 @@ export async function requireAuth(req: Request, pool: Pool): Promise<UserContext
       [email]
     );
     const invite = inviteResult.rows[0] as {role?: string; status?: string} | undefined;
+    if (!email) {
+      throw new ApiError(403, "Invited email account required");
+    }
+    if (!invite) {
+      throw new ApiError(403, "This app is invite-only");
+    }
     if (invite?.status === "disabled") {
       throw new ApiError(403, "This account is disabled");
     }

--- a/hosting/index.html
+++ b/hosting/index.html
@@ -986,17 +986,22 @@
           if (user) {
             $("authEmail").value = user.email || "";
             $("authSignOut").hidden = false;
-            const anonymous = Boolean(user.isAnonymous);
-            $("authSignIn").hidden = !anonymous;
-            $("authCreate").hidden = !anonymous;
-            $("authPassword").hidden = !anonymous;
+            $("authSignIn").hidden = true;
+            $("authCreate").hidden = true;
+            $("authPassword").hidden = true;
             if (currentUserProfile?.user) $("topStatus").textContent = `Signed in as ${currentUserProfile.user.email || "anonymous"}`;
-            else $("topStatus").textContent = anonymous ? "Anonymous session" : `Signed in as ${user.email || "user"}`;
+            else $("topStatus").textContent = `Signed in as ${user.email || "user"}`;
+          } else {
+            $("authSignOut").hidden = true;
+            $("authSignIn").hidden = false;
+            $("authCreate").hidden = false;
+            $("authPassword").hidden = false;
+            $("topStatus").textContent = "Sign in with an invited email account";
           }
         });
         await auth.authStateReady();
-        const result = auth.currentUser ? { user: auth.currentUser } : await authModule.signInAnonymously(auth);
-        return () => authModule.getIdToken(result.user, true);
+        if (!auth.currentUser) return null;
+        return () => authModule.getIdToken(auth.currentUser, true);
       } catch (error) {
         console.warn("Firebase authentication is unavailable", error);
         return null;


### PR DESCRIPTION
﻿## Summary
- require Firebase users to match an invited email in `app_user_invites`
- stop the hosted UI from silently creating anonymous Firebase sessions
- show an invited-email sign-in prompt when no user is signed in

## Validation
- `npm.cmd --prefix functions run build`
- `firebase.cmd deploy --only functions,hosting --project moneymaker-aedf7`
- verified `/api/health` returns online/green
- verified unauthenticated `/api/profile` returns `401 Sign-in required`
- verified a temporary uninvited Firebase email account returns `403 This app is invite-only`, then deleted the temp account
- verified hosted `index.html` no longer contains `signInAnonymously` and does contain the invited-email prompt

## Notes
Brady and Damien still need to create/sign in with their invited email accounts before the real three-user isolation test can be completed.
