### PR TITLE
Add Firebase deploy workflow

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,70 @@
+name: Firebase deploy
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: Firebase deploy targets
+        required: false
+        default: hosting,functions
+
+concurrency:
+  group: firebase-deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Firebase app
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success')
+    permissions:
+      contents: read
+    env:
+      FIREBASE_PROJECT_ID: moneymaker-aedf7
+      FIREBASE_DEPLOY_TARGETS: ${{ github.event.inputs.targets || vars.FIREBASE_DEPLOY_TARGETS || 'hosting,functions' }}
+      HAS_FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONEYMAKER_AEDF7 != '' }}
+    steps:
+      - name: Skip until Firebase service account secret exists
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT != 'true'
+        run: echo "Skipping deploy because FIREBASE_SERVICE_ACCOUNT_MONEYMAKER_AEDF7 is not configured."
+
+      - name: Check out repository
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install Functions dependencies
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        run: npm ci
+        working-directory: functions
+
+      - name: Build Functions
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        run: npm run build
+        working-directory: functions
+
+      - name: Authenticate to Google Cloud
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MONEYMAKER_AEDF7 }}
+
+      - name: Deploy Firebase targets
+        if: env.HAS_FIREBASE_SERVICE_ACCOUNT == 'true'
+        run: npx firebase-tools@latest deploy --project "$FIREBASE_PROJECT_ID" --only "$FIREBASE_DEPLOY_TARGETS" --non-interactive


### PR DESCRIPTION
Adds a Firebase deploy workflow that runs after the CI workflow succeeds on main, plus manual workflow_dispatch support. The deploy job builds Functions before deploying and skips cleanly until FIREBASE_SERVICE_ACCOUNT_MONEYMAKER_AEDF7 is configured as a GitHub Actions secret. Default deploy targets are hosting,functions and can be overridden with the FIREBASE_DEPLOY_TARGETS repository variable or manual dispatch input.

Validation:
- npm.cmd --prefix functions run build
- py -m pytest src/moneymaker/tests